### PR TITLE
Temporarily shorten tenancy review delay for frontend testing

### DIFF
--- a/property/propertylist_app/api/serializers.py
+++ b/property/propertylist_app/api/serializers.py
@@ -602,9 +602,14 @@ class TenancyRespondSerializer(serializers.Serializer):
         def _set_schedule_fields():
             end_date = _compute_end_date(tenancy.move_in_date, tenancy.duration_months)
             # review opens end + 7 days (your rule)
+            # tenancy.review_open_at = timezone.make_aware(
+            #     timezone.datetime.combine(end_date, timezone.datetime.min.time())
+            # ) + timedelta(days=7)
+            
+            # Temporary frontend testing rule: review opens 30 minutes after tenancy ends.
             tenancy.review_open_at = timezone.make_aware(
                 timezone.datetime.combine(end_date, timezone.datetime.min.time())
-            ) + timedelta(days=7)
+            ) + timedelta(minutes=30)
 
             # optional deadline: end + 60 days (safe default)
             tenancy.review_deadline_at = tenancy.review_open_at + timedelta(days=60)

--- a/property/propertylist_app/services/tenancy_dates.py
+++ b/property/propertylist_app/services/tenancy_dates.py
@@ -14,7 +14,10 @@ def compute_review_window(move_in_date, duration_months):
     # use midnight of end_date in current timezone to keep dates stable
     end_midnight = timezone.make_aware(datetime.combine(end_date, time.min))
 
-    review_open_at = end_midnight + timedelta(days=7)
+
+    # Temporary frontend testing rule: review opens 30 minutes after tenancy ends.
+    #review_open_at = end_midnight + timedelta(days=7)
+    review_open_at = end_midnight + timedelta(minutes=30)
     review_deadline_at = review_open_at + timedelta(days=30)
     still_living_check_at = end_midnight - timedelta(days=7)
 


### PR DESCRIPTION
## What changed

Temporarily reduced the tenancy review activation delay from 7 days to 30 minutes for frontend/local testing.

Changes made in:

- propertylist_app/services/tenancy_dates.py
- propertylist_app/api/serializers.py

## Why

Allows frontend developers to test the review workflow without waiting 7 days after a tenancy ends.

This is a temporary testing change and will be reverted before production release.

## Area

- [x] Backend
- [ ] Web
- [ ] Mobile
- [ ] Docs
- [ ] Fix
- [ ] Chore

## Testing

- Python compilation passed.
- Verified only the two review scheduling files are modified.