### PR TITLE
Add tenancy participant names and landlord viewings endpoint

### DIFF
--- a/property/propertylist_app/api/serializers.py
+++ b/property/propertylist_app/api/serializers.py
@@ -678,20 +678,63 @@ class TenancyDetailSerializer(serializers.ModelSerializer):
     can_leave_review = serializers.SerializerMethodField()
     review_button_reason = serializers.SerializerMethodField()
     profile_image = serializers.SerializerMethodField()
+    tenant_name = serializers.SerializerMethodField()
+    landlord_name = serializers.SerializerMethodField()
 
     class Meta:
         model = Tenancy
         fields = [
-            "id", "room", "landlord", "tenant", "profile_image", "proposed_by",
-            "move_in_date", "duration_months",
-            "landlord_confirmed_at", "tenant_confirmed_at",
-            "status",
-            "review_open_at", "review_deadline_at",
-            "can_leave_review", "review_button_reason",
-            "still_living_check_at", "still_living_confirmed_at",
-            "created_at", "updated_at",
-        ]
+                "id",
+                "room",
+                "landlord",
+                "landlord_name",
+                "tenant",
+                "tenant_name",
+                "profile_image",
+                "proposed_by",
+                "move_in_date",
+                "duration_months",
+                "landlord_confirmed_at",
+                "tenant_confirmed_at",
+                "status",
+                "review_open_at",
+                "review_deadline_at",
+                "can_leave_review",
+                "review_button_reason",
+                "still_living_check_at",
+                "still_living_confirmed_at",
+                "created_at",
+                "updated_at",
+            ]
+                    
         read_only_fields = fields
+        
+        
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_tenant_name(self, obj):
+        tenant = getattr(obj, "tenant", None)
+
+        if tenant is None:
+            return None
+
+        full_name = tenant.get_full_name().strip()
+
+        return full_name or tenant.username
+
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_landlord_name(self, obj):
+        landlord = getattr(obj, "landlord", None)
+
+        if landlord is None:
+            return None
+
+        full_name = landlord.get_full_name().strip()
+
+        return full_name or landlord.username
+        
+        
+        
 
     @extend_schema_field(OpenApiTypes.URI)
     def get_profile_image(self, obj):

--- a/property/propertylist_app/api/urls.py
+++ b/property/propertylist_app/api/urls.py
@@ -42,7 +42,7 @@ from propertylist_app.api.views import (
     MessageThreadStateView,MessageStatsView,InboxListView,
 
     # Bookings & Availability
-    create_booking, BookingListCreateView, BookingDetailView, BookingCancelView,BookingRescheduleView,
+    create_booking, BookingListCreateView, LandlordViewingsListView, BookingDetailView, BookingCancelView, BookingRescheduleView,
     RoomAvailabilityView, RoomAvailabilitySlotListCreateView, RoomAvailabilitySlotDeleteView, RoomAvailabilityPublicView,  FindAddressView,BookingDeleteView,
     BookingSuspendView,
 
@@ -179,9 +179,23 @@ urlpatterns = [
 
 
     # --- Bookings / viewings ---
-    path("bookings/create/",               create_booking,                  name="booking-create"),
-    path("bookings/",                      BookingListCreateView.as_view(), name="bookings-list-create"),
-    path("bookings/<int:pk>/",             BookingDetailView.as_view(),     name="booking-detail"),
+    # --- Bookings / viewings ---
+    path("bookings/create/", create_booking, name="booking-create"),
+    path(
+        "bookings/landlord-viewings/",
+        LandlordViewingsListView.as_view(),
+        name="landlord-viewings-list",
+    ),
+    path(
+        "bookings/",
+        BookingListCreateView.as_view(),
+        name="bookings-list-create",
+    ),
+    path(
+        "bookings/<int:pk>/",
+        BookingDetailView.as_view(),
+        name="booking-detail",
+    ),
     path("bookings/<int:pk>/cancel/",      BookingCancelView.as_view(),     name="booking-cancel"),
     path("bookings/<int:pk>/reschedule/",  BookingRescheduleView.as_view(), name="booking-reschedule",),
     path("rooms/<int:pk>/availability/",   RoomAvailabilityView.as_view(),  name="room-availability"),

--- a/property/propertylist_app/api/views/__init__.py
+++ b/property/propertylist_app/api/views/__init__.py
@@ -80,6 +80,7 @@ from .messaging import (
 from .bookings import (
     create_booking,
     BookingListCreateView,
+    LandlordViewingsListView,
     BookingDetailView,
     BookingCancelView,
     BookingDeleteView,

--- a/property/propertylist_app/api/views/bookings.py
+++ b/property/propertylist_app/api/views/bookings.py
@@ -429,6 +429,149 @@ class BookingListCreateView(generics.ListCreateAPIView):
 
 
 
+class LandlordViewingsListView(generics.ListAPIView):
+    """
+    Return all viewing bookings for rooms owned by the authenticated landlord.
+    """
+
+    serializer_class = BookingSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = StandardLimitOffsetPagination
+    throttle_classes = [UserRateThrottle]
+    filter_backends = [filters.OrderingFilter]
+    ordering_fields = ["start", "end", "created_at", "id"]
+    ordering = ["-created_at"]
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Booking.objects.none()
+
+        return (
+            Booking.objects
+            .filter(
+                room__property_owner=self.request.user,
+                is_deleted=False,
+            )
+            .select_related(
+                "room",
+                "user",
+                "slot",
+            )
+            .order_by("-created_at")
+        )
+
+    @extend_schema(
+        responses={
+            200: inline_serializer(
+                name="PaginatedLandlordViewingsListResponse",
+                fields={
+                    "ok": serializers.BooleanField(),
+                    "message": serializers.CharField(
+                        required=False,
+                        allow_null=True,
+                    ),
+                    "data": BookingSerializer(many=True),
+                    "meta": inline_serializer(
+                        name="LandlordViewingsListMeta",
+                        fields={
+                            "count": serializers.IntegerField(),
+                            "next": serializers.CharField(
+                                required=False,
+                                allow_null=True,
+                            ),
+                            "previous": serializers.CharField(
+                                required=False,
+                                allow_null=True,
+                            ),
+                        },
+                    ),
+                    "count": serializers.IntegerField(
+                        required=False,
+                        allow_null=True,
+                    ),
+                    "next": serializers.CharField(
+                        required=False,
+                        allow_null=True,
+                    ),
+                    "previous": serializers.CharField(
+                        required=False,
+                        allow_null=True,
+                    ),
+                    "results": BookingSerializer(
+                        many=True,
+                        required=False,
+                    ),
+                },
+            ),
+            401: OpenApiResponse(response=ErrorResponseSerializer),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="limit",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Maximum number of landlord viewings to return.",
+            ),
+            OpenApiParameter(
+                name="offset",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Number of landlord viewings to skip.",
+            ),
+            OpenApiParameter(
+                name="ordering",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Sort by start, end, created_at, id, "
+                    "or their descending variants."
+                ),
+            ),
+        ],
+        description=(
+            "List all non-deleted viewing bookings across rooms owned by "
+            "the authenticated landlord."
+        ),
+    )
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            meta = _pagination_meta(self.paginator)
+
+            return Response(
+                {
+                    "ok": True,
+                    "message": None,
+                    "data": serializer.data,
+                    "meta": meta,
+                    "count": meta.get("count"),
+                    "next": meta.get("next"),
+                    "previous": meta.get("previous"),
+                    "results": serializer.data,
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        serializer = self.get_serializer(queryset, many=True)
+
+        return Response(
+            {
+                "ok": True,
+                "message": None,
+                "data": serializer.data,
+                "results": serializer.data,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+
 
 class BookingDetailView(generics.RetrieveAPIView):
     """GET /api/bookings/<id>/ â†’ see my booking"""

--- a/property/propertylist_app/tests/bookings/test_landlord_viewings.py
+++ b/property/propertylist_app/tests/bookings/test_landlord_viewings.py
@@ -1,0 +1,228 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from propertylist_app.models import Booking, Room, RoomCategorie
+
+
+def create_room(*, owner, category, title):
+    return Room.objects.create(
+        title=title,
+        description="",
+        price_per_month=Decimal("750"),
+        location="",
+        category=category,
+        property_owner=owner,
+        number_of_bedrooms=1,
+        number_of_bathrooms=1,
+        property_type="flat",
+        avg_rating=4.0,
+    )
+
+
+@pytest.mark.django_db
+def test_landlord_viewings_returns_only_bookings_for_owned_rooms():
+    landlord = User.objects.create_user(
+        username="landlord",
+        email="landlord@example.com",
+        password="pass12345",
+    )
+    other_landlord = User.objects.create_user(
+        username="other_landlord",
+        email="other-landlord@example.com",
+        password="pass12345",
+    )
+    tenant_one = User.objects.create_user(
+        username="tenant_one",
+        email="tenant-one@example.com",
+        password="pass12345",
+    )
+    tenant_two = User.objects.create_user(
+        username="tenant_two",
+        email="tenant-two@example.com",
+        password="pass12345",
+    )
+
+    category = RoomCategorie.objects.create(
+        name="Central",
+        active=True,
+    )
+
+    landlord_room_one = create_room(
+        owner=landlord,
+        category=category,
+        title="Landlord Room One",
+    )
+    landlord_room_two = create_room(
+        owner=landlord,
+        category=category,
+        title="Landlord Room Two",
+    )
+    other_landlord_room = create_room(
+        owner=other_landlord,
+        category=category,
+        title="Other Landlord Room",
+    )
+
+    now = timezone.now()
+
+    booking_one = Booking.objects.create(
+        user=tenant_one,
+        room=landlord_room_one,
+        start=now + timedelta(days=1),
+        end=now + timedelta(days=1, hours=1),
+    )
+    booking_two = Booking.objects.create(
+        user=tenant_two,
+        room=landlord_room_two,
+        start=now + timedelta(days=2),
+        end=now + timedelta(days=2, hours=1),
+    )
+    other_landlord_booking = Booking.objects.create(
+        user=tenant_one,
+        room=other_landlord_room,
+        start=now + timedelta(days=3),
+        end=now + timedelta(days=3, hours=1),
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=landlord)
+
+    response = client.get(
+        reverse("v1:landlord-viewings-list")
+    )
+
+    assert response.status_code == 200
+
+    returned_ids = [
+        booking["id"]
+        for booking in response.data["results"]
+    ]
+
+    assert set(returned_ids) == {
+        booking_one.id,
+        booking_two.id,
+    }
+    assert other_landlord_booking.id not in returned_ids
+
+
+@pytest.mark.django_db
+def test_landlord_viewings_excludes_soft_deleted_bookings():
+    landlord = User.objects.create_user(
+        username="landlord",
+        email="landlord@example.com",
+        password="pass12345",
+    )
+    tenant = User.objects.create_user(
+        username="tenant",
+        email="tenant@example.com",
+        password="pass12345",
+    )
+
+    category = RoomCategorie.objects.create(
+        name="Central",
+        active=True,
+    )
+    room = create_room(
+        owner=landlord,
+        category=category,
+        title="Landlord Room",
+    )
+
+    now = timezone.now()
+
+    visible_booking = Booking.objects.create(
+        user=tenant,
+        room=room,
+        start=now + timedelta(days=1),
+        end=now + timedelta(days=1, hours=1),
+    )
+    deleted_booking = Booking.objects.create(
+        user=tenant,
+        room=room,
+        start=now + timedelta(days=2),
+        end=now + timedelta(days=2, hours=1),
+    )
+
+    Booking.objects.filter(
+        pk=deleted_booking.pk
+    ).update(
+        is_deleted=True
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=landlord)
+
+    response = client.get(
+        reverse("v1:landlord-viewings-list")
+    )
+
+    assert response.status_code == 200
+
+    returned_ids = [
+        booking["id"]
+        for booking in response.data["results"]
+    ]
+
+    assert visible_booking.id in returned_ids
+    assert deleted_booking.id not in returned_ids
+
+
+@pytest.mark.django_db
+def test_user_without_owned_rooms_gets_empty_landlord_viewings_list():
+    landlord = User.objects.create_user(
+        username="landlord",
+        email="landlord@example.com",
+        password="pass12345",
+    )
+    tenant = User.objects.create_user(
+        username="tenant",
+        email="tenant@example.com",
+        password="pass12345",
+    )
+
+    category = RoomCategorie.objects.create(
+        name="Central",
+        active=True,
+    )
+    room = create_room(
+        owner=landlord,
+        category=category,
+        title="Landlord Room",
+    )
+
+    now = timezone.now()
+
+    Booking.objects.create(
+        user=tenant,
+        room=room,
+        start=now + timedelta(days=1),
+        end=now + timedelta(days=1, hours=1),
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=tenant)
+
+    response = client.get(
+        reverse("v1:landlord-viewings-list")
+    )
+
+    assert response.status_code == 200
+    assert response.data["results"] == []
+    assert response.data["count"] in (0, None)
+
+
+@pytest.mark.django_db
+def test_landlord_viewings_requires_authentication():
+    client = APIClient()
+
+    response = client.get(
+        reverse("v1:landlord-viewings-list")
+    )
+
+    assert response.status_code == 401


### PR DESCRIPTION
- Add tenant_name and landlord_name to tenancy responses
- Add GET /api/v1/bookings/landlord-viewings/
- Return bookings across all rooms owned by the authenticated landlord
- Exclude other landlords' and soft-deleted bookings
- Add authentication and access-control regression tests
- 90 related tests passing
