### PR TITLE
Strengthen input validation, throttling and public photo moderation

### DIFF
--- a/property/property/settings.py
+++ b/property/property/settings.py
@@ -328,6 +328,7 @@ REST_FRAMEWORK = {
 
         "user": "1000/hour",
         "anon": "100/hour",
+        "room-create": "10/hour",
 
         "login": "5/minute",
         "register": "5/hour",

--- a/property/property/settings_test.py
+++ b/property/property/settings_test.py
@@ -53,6 +53,7 @@ REST_FRAMEWORK = {
         # Baselines; tests narrow these when needed:
         "user": "10000/hour",
         "anon": "10000/hour",
+        "room-create": "10000/hour",
         "otp-verify": "10000/hour",
         "otp-resend": "10000/hour",
 

--- a/property/propertylist_app/api/serializers.py
+++ b/property/propertylist_app/api/serializers.py
@@ -32,10 +32,10 @@ from propertylist_app.validators import (
     validate_listing_photos, sanitize_search_text, validate_numeric_range,
     validate_radius_miles, validate_pagination, validate_ordering,
     normalise_price, normalise_phone, normalise_name, normalise_email,
-    sanitize_plain_text,
+    sanitize_plain_text, validate_plain_text,
     assert_not_duplicate_listing, assert_no_duplicate_files,
     enforce_user_caps,
-)
+    )
 from propertylist_app.services.geo import geocode_postcode_cached
 
 from django.utils import timezone
@@ -1679,37 +1679,25 @@ class RoomSerializer(serializers.ModelSerializer):
                 .first()
             )
 
-        if first_image and first_image.image:
-            url = first_image.image.url
-        elif getattr(obj, "image", None):
-            url = obj.image.url
-        else:
+        if not first_image or not first_image.image:
             return None
 
-        request = self.context.get("request")
-        if request is not None:
-            return request.build_absolute_uri(url)
-        return url
+        url = first_image.image.url
 
         request = self.context.get("request")
         if request is not None:
             return request.build_absolute_uri(url)
+
         return url
 
     @extend_schema_field(OpenApiTypes.INT)
-    def get_photo_count(self, obj):
-        val = getattr(obj, "photo_count", None)
-        if val is not None:
-            return val
-
+    def get_photo_count(self, obj) -> int:
         approved_images = getattr(obj, "prefetched_approved_images", None)
-        if approved_images is not None:
-            approved = len(approved_images)
-        else:
-            approved = obj.roomimage_set.filter(status="approved").count()
 
-        legacy = 1 if getattr(obj, "image", None) else 0
-        return approved + legacy
+        if approved_images is not None:
+            return len(approved_images)
+
+        return obj.roomimage_set.filter(status="approved").count()
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_listing_state(self, obj) -> str:
@@ -1852,6 +1840,9 @@ class SearchFiltersSerializer(serializers.Serializer):
     def validate_postcode(self, value):
         value = sanitize_plain_text(value, max_len=20).upper()
         return normalize_uk_postcode(value)
+    
+ 
+    
 
     def validate_street(self, value):
         return sanitize_plain_text(value, max_len=120)
@@ -2346,6 +2337,31 @@ class UserProfileSerializer(serializers.ModelSerializer):
             return normalize_uk_postcode(value)
         except Exception:
             raise serializers.ValidationError("Invalid UK postcode.")
+        
+        
+    def validate_occupation(self, value):
+        if value is None:
+            return ""
+
+        value = validate_plain_text(value)
+
+        if not value:
+            return ""
+
+        return value
+
+    def validate_about_you(self, value):
+        if value is None:
+            return ""
+
+        value = validate_plain_text(value)
+
+        if not value:
+            return ""
+
+        return value    
+        
+        
 
     def validate_date_of_birth(self, value):
         if not value:
@@ -2659,15 +2675,19 @@ class ContactMessageSerializer(serializers.ModelSerializer):
         return normalise_email(value)
 
     def validate_subject(self, value):
-        value = sanitize_plain_text(value, max_len=200)
+        value = validate_plain_text(value, max_len=200)
+
         if not value:
             raise serializers.ValidationError("Subject is required.")
+
         return value
 
     def validate_message(self, value):
-        value = sanitize_plain_text(value, max_len=5000)
+        value = validate_plain_text(value, max_len=5000)
+
         if not value:
             raise serializers.ValidationError("Message is required.")
+
         return value
 
 

--- a/property/propertylist_app/api/throttling.py
+++ b/property/propertylist_app/api/throttling.py
@@ -54,6 +54,36 @@ class MessageUserThrottle(SimpleRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
+class RoomCreateThrottle(SimpleRateThrottle):
+    """
+    Per-user throttle for creating room listings.
+
+    Only authenticated POST requests are counted. Reading the public room
+    list does not consume this throttle allowance.
+    """
+
+    scope = "room-create"
+
+    def get_rate(self):
+        return api_settings.DEFAULT_THROTTLE_RATES.get(self.scope)
+
+    def get_cache_key(self, request, view):
+        if request.method != "POST":
+            return None
+
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return None
+
+        ident = str(user.pk)
+
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": ident,
+        }
+
+
+
 class  ReviewCreateThrottle(UserRateThrottle):
   scope = 'review-create'
 
@@ -69,6 +99,15 @@ class RegisterScopedThrottle(ScopedRateThrottle):
 
 class PasswordResetScopedThrottle(ScopedRateThrottle):
     scope = "password-reset"
+
+    def get_rate(self):
+        """
+        Read the current configured rate.
+
+        This keeps production settings authoritative and allows focused tests
+        to temporarily override this scope without stale DRF cached values.
+        """
+        return api_settings.DEFAULT_THROTTLE_RATES.get(self.scope)
 
 class PasswordResetConfirmScopedThrottle(ScopedRateThrottle):
     scope = "password-reset-confirm"

--- a/property/propertylist_app/api/views/auth.py
+++ b/property/propertylist_app/api/views/auth.py
@@ -1286,6 +1286,7 @@ class TokenRefreshView(APIView):
 class PasswordResetRequestView(APIView):
     permission_classes = [AllowAny]
     throttle_classes = [PasswordResetScopedThrottle]
+    throttle_scope = "password-reset"
     versioning_class = None
 
     @extend_schema(

--- a/property/propertylist_app/api/views/public.py
+++ b/property/propertylist_app/api/views/public.py
@@ -410,7 +410,9 @@ class SearchRoomsView(CachedAnonymousGETMixin, generics.ListAPIView):
             .prefetch_related(
                 Prefetch(
                     "roomimage_set",
-                    queryset=RoomImage.objects.filter(status__in=["approved", "pending"]).order_by("id"),
+                    queryset=RoomImage.objects.filter(
+                        status="approved"
+                    ).order_by("id"),
                     to_attr="prefetched_approved_images",
                 )
             )
@@ -641,7 +643,7 @@ class SearchRoomsView(CachedAnonymousGETMixin, generics.ListAPIView):
             qs = qs.annotate(
                 _has_approved_photo=Exists(approved_photo_exists)
             ).filter(
-                Q(_has_approved_photo=True) | (Q(image__isnull=False) & ~Q(image=""))
+                _has_approved_photo=True
             )
 
 

--- a/property/propertylist_app/api/views/rooms.py
+++ b/property/propertylist_app/api/views/rooms.py
@@ -54,6 +54,7 @@ from propertylist_app.validators import (
 )
 from propertylist_app.api.pagination import StandardLimitOffsetPagination
 from propertylist_app.api.permissions import IsAdminOrReadOnly, IsOwnerOrReadOnly
+from propertylist_app.api.throttling import RoomCreateThrottle
 from propertylist_app.api.schema_serializers import ErrorResponseSerializer
 from propertylist_app.api.schema_helpers import standard_response_serializer,standard_paginated_response_serializer
 from propertylist_app.api.serializers import (
@@ -219,7 +220,7 @@ class RoomListGV(CachedAnonymousGETMixin, generics.ListAPIView):
       
       
 class RoomAV(APIView):
-    throttle_classes = [AnonRateThrottle]
+    throttle_classes = [AnonRateThrottle, RoomCreateThrottle]
     permission_classes = [IsAuthenticatedOrReadOnly]
 
 

--- a/property/propertylist_app/tests/account/test_batch2_profile_live_ready.py
+++ b/property/propertylist_app/tests/account/test_batch2_profile_live_ready.py
@@ -30,6 +30,22 @@ def _payload_data(body):
     return body
 
 
+def _field_errors(body):
+    if not isinstance(body, dict):
+        return {}
+
+    if isinstance(body.get("field_errors"), dict):
+        return body["field_errors"]
+
+    if isinstance(body.get("details"), dict):
+        return body["details"]
+
+    if isinstance(body.get("errors"), dict):
+        return body["errors"]
+
+    return body
+
+
 def test_user_profile_get_returns_profile(api_client):
     user = make_user()
     url = reverse("api:user-profile")
@@ -38,6 +54,7 @@ def test_user_profile_get_returns_profile(api_client):
     response = api_client.get(url, format="json")
 
     assert response.status_code == 200, response.json()
+
     body = response.json()
     data = _payload_data(body)
 
@@ -69,6 +86,7 @@ def test_user_profile_patch_updates_fields(api_client):
     assert response.status_code == 200, response.json()
 
     profile = UserProfile.objects.get(user=user)
+
     assert profile.occupation == "Software engineer"
     assert profile.postcode == "SW1A 1AA"
     assert str(profile.date_of_birth) == "1990-01-01"
@@ -76,6 +94,79 @@ def test_user_profile_patch_updates_fields(api_client):
     assert profile.role == "seeker"
     assert profile.role_detail == "current_flatmate"
     assert profile.address_manual == "10 Downing Street, London"
+    assert profile.about_you == "Friendly and tidy."
+
+
+def test_user_profile_rejects_html_in_occupation(api_client):
+    user = make_user()
+    url = reverse("api:user-profile")
+
+    api_client.force_authenticate(user=user)
+    response = api_client.patch(
+        url,
+        {
+            "occupation": "<script>alert(1)</script>",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400, response.json()
+
+    body = response.json()
+    field_errors = _field_errors(body)
+
+    assert "occupation" in field_errors
+
+    profile = UserProfile.objects.get(user=user)
+    assert profile.occupation != "<script>alert(1)</script>"
+
+
+def test_user_profile_rejects_html_in_about_you(api_client):
+    user = make_user()
+    url = reverse("api:user-profile")
+
+    api_client.force_authenticate(user=user)
+    response = api_client.patch(
+        url,
+        {
+            "about_you": "<img src=x onerror=alert(1)>",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400, response.json()
+
+    body = response.json()
+    field_errors = _field_errors(body)
+
+    assert "about_you" in field_errors
+
+    profile = UserProfile.objects.get(user=user)
+    assert profile.about_you != "<img src=x onerror=alert(1)>"
+
+
+def test_user_profile_rejects_dangerous_javascript_scheme(api_client):
+    user = make_user()
+    url = reverse("api:user-profile")
+
+    api_client.force_authenticate(user=user)
+    response = api_client.patch(
+        url,
+        {
+            "about_you": "javascript:alert(1)",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400, response.json()
+
+    body = response.json()
+    field_errors = _field_errors(body)
+
+    assert "about_you" in field_errors
+
+    profile = UserProfile.objects.get(user=user)
+    assert profile.about_you != "javascript:alert(1)"
 
 
 def test_onboarding_complete_sets_flag(api_client):
@@ -83,9 +174,14 @@ def test_onboarding_complete_sets_flag(api_client):
     url = reverse("api:user-onboarding-complete")
 
     api_client.force_authenticate(user=user)
-    response = api_client.post(url, {"confirm": True}, format="json")
+    response = api_client.post(
+        url,
+        {"confirm": True},
+        format="json",
+    )
 
     assert response.status_code == 200, response.json()
+
     body = response.json()
 
     assert body["ok"] is True
@@ -98,11 +194,19 @@ def test_onboarding_complete_sets_flag(api_client):
 def test_profile_page_returns_expected_shape(api_client):
     user = make_user()
     profile = UserProfile.objects.get(user=user)
+
     profile.occupation = "Designer"
     profile.postcode = "SW1A 1AA"
     profile.address_manual = "London"
     profile.about_you = "Hello"
-    profile.save(update_fields=["occupation", "postcode", "address_manual", "about_you"])
+    profile.save(
+        update_fields=[
+            "occupation",
+            "postcode",
+            "address_manual",
+            "about_you",
+        ]
+    )
 
     url = reverse("api:user-profile-page")
 
@@ -110,9 +214,11 @@ def test_profile_page_returns_expected_shape(api_client):
     response = api_client.get(url, format="json")
 
     assert response.status_code == 200, response.json()
+
     body = response.json()
 
     assert body["ok"] is True
+
     data = body["data"]
 
     assert data["id"] == user.id

--- a/property/propertylist_app/tests/auth/test_batch1_password_reset_live_ready.py
+++ b/property/propertylist_app/tests/auth/test_batch1_password_reset_live_ready.py
@@ -21,8 +21,11 @@ import pytest
 from django.contrib.auth import authenticate, get_user_model
 from django.urls import reverse
 
-from propertylist_app.models import EmailOTP
+from rest_framework.settings import api_settings
 
+
+from propertylist_app.models import EmailOTP
+from django.core.cache import caches
 pytestmark = pytest.mark.django_db
 
 
@@ -113,3 +116,47 @@ def test_password_reset_confirm_wrong_token_increments_attempts(api_client):
     otp.refresh_from_db()
     assert otp.attempts == 1
     assert otp.used_at is None
+    
+    
+    
+def test_password_reset_request_is_throttled_after_three_requests(
+    api_client,
+    settings,
+    monkeypatch,
+):
+    """
+    Password-reset requests are limited by IP.
+
+    The first three requests are allowed.
+    The fourth request from the same IP must return HTTP 429.
+    """
+    monkeypatch.setitem(
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"],
+        "password-reset",
+        "3/hour",
+    )
+
+    api_settings.reload()
+    caches["default"].clear()
+
+    url = reverse("api:auth-password-reset")
+    request_ip = "203.0.113.90"
+
+    for index in range(3):
+        response = api_client.post(
+            url,
+            {"email": f"reset-target-{index}@example.com"},
+            format="json",
+            REMOTE_ADDR=request_ip,
+        )
+
+        assert response.status_code == 200, response.json()
+
+    throttled_response = api_client.post(
+        url,
+        {"email": "reset-target-4@example.com"},
+        format="json",
+        REMOTE_ADDR=request_ip,
+    )
+
+    assert throttled_response.status_code == 429, throttled_response.json()

--- a/property/propertylist_app/tests/home/test_contact_form.py
+++ b/property/propertylist_app/tests/home/test_contact_form.py
@@ -54,3 +54,50 @@ class ContactFormTests(APITestCase):
         resp = self.client.post(self.url, data=payload, format="json")
 
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        
+        
+        
+    def test_contact_rejects_html_in_subject(self):
+        payload = {
+            "name": "Security Tester",
+            "email": "security@example.com",
+            "subject": "<img src=x onerror=alert(1)>",
+            "message": "Normal support message.",
+        }
+
+        resp = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("errors", resp.data)
+        self.assertIn("subject", resp.data["errors"])
+        self.assertEqual(ContactMessage.objects.count(), 0)
+
+    def test_contact_rejects_html_in_message(self):
+        payload = {
+            "name": "Security Tester",
+            "email": "security@example.com",
+            "subject": "Support request",
+            "message": "<script>alert(1)</script>",
+        }
+
+        resp = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("errors", resp.data)
+        self.assertIn("message", resp.data["errors"])
+        self.assertEqual(ContactMessage.objects.count(), 0)
+
+    def test_contact_rejects_dangerous_javascript_scheme(self):
+        payload = {
+            "name": "Security Tester",
+            "email": "security@example.com",
+            "subject": "javascript:alert(1)",
+            "message": "Normal support message.",
+        }
+
+        resp = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("errors", resp.data)
+        self.assertIn("subject", resp.data["errors"])
+        self.assertEqual(ContactMessage.objects.count(), 0)    

--- a/property/propertylist_app/tests/search/test_photos_only_filter.py
+++ b/property/propertylist_app/tests/search/test_photos_only_filter.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import timedelta
 
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -9,55 +10,186 @@ from rest_framework.test import APIClient
 from propertylist_app.models import Room, RoomCategorie, RoomImage
 
 
+def extract_results(response):
+    """
+    Support both the standard RentCrib response envelope and a direct
+    paginated/list response.
+    """
+    payload = response.data
+
+    if isinstance(payload, dict) and "data" in payload:
+        payload = payload["data"]
+
+    if isinstance(payload, dict) and "results" in payload:
+        return payload["results"]
+
+    return payload
+
+
+def create_active_room(*, owner, category, title, legacy_image=None):
+    return Room.objects.create(
+        title=title,
+        category=category,
+        price_per_month=800,
+        property_owner=owner,
+        image=legacy_image,
+        status="active",
+        paid_until=timezone.now().date() + timedelta(days=30),
+    )
+
+
 @pytest.mark.django_db
-def test_search_photos_only_returns_rooms_with_legacy_or_approved_photos():
+def test_search_photos_only_returns_only_rooms_with_approved_photos():
+    cache.clear()
+
     owner = User.objects.create_user(
-        username="o1",
+        username="photo_filter_owner",
         password="pass123",
-        email="o1@example.com",
+        email="photo-filter-owner@example.com",
     )
-    cat = RoomCategorie.objects.create(name="Any", active=True)
-    paid_until = timezone.now().date() + timedelta(days=30)
+    category = RoomCategorie.objects.create(
+        name="Photo Filter",
+        active=True,
+    )
 
-    # Room A: no legacy image + no RoomImage => should NOT return
-    Room.objects.create(
+    create_active_room(
+        owner=owner,
+        category=category,
         title="NoPhotos",
-        category=cat,
-        price_per_month=800,
-        property_owner=owner,
-        paid_until=paid_until,
     )
 
-    # Room B: has legacy image => should return
-    Room.objects.create(
+    create_active_room(
+        owner=owner,
+        category=category,
         title="LegacyPhoto",
-        category=cat,
-        price_per_month=800,
-        property_owner=owner,
-        image="rooms/x.jpg",
-        paid_until=paid_until,
+        legacy_image="rooms/legacy.jpg",
     )
 
-    # Room C: has RoomImage approved => should return
-    r_img = Room.objects.create(
-        title="ApprovedPhoto",
-        category=cat,
-        price_per_month=800,
-        property_owner=owner,
-        paid_until=paid_until,
+    pending_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="PendingPhoto",
     )
     RoomImage.objects.create(
-        room=r_img,
-        image="rooms/y.jpg",
+        room=pending_room,
+        image="rooms/pending.jpg",
+        status="pending",
+    )
+
+    rejected_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="RejectedPhoto",
+    )
+    RoomImage.objects.create(
+        room=rejected_room,
+        image="rooms/rejected.jpg",
+        status="rejected",
+    )
+
+    approved_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="ApprovedPhoto",
+    )
+    RoomImage.objects.create(
+        room=approved_room,
+        image="rooms/approved.jpg",
         status="approved",
     )
 
-    url = reverse("v1:search-rooms")
-    res = APIClient().get(url, {"photos_only": "true"})
-    assert res.status_code == 200
-    results = res.data.get("results", res.data)
-    titles = {x["title"] for x in results}
+    response = APIClient().get(
+        reverse("v1:search-rooms"),
+        {"photos_only": "true"},
+    )
+
+    assert response.status_code == 200, response.data
+
+    results = extract_results(response)
+    titles = {item["title"] for item in results}
 
     assert "NoPhotos" not in titles
-    assert "LegacyPhoto" in titles
+    assert "LegacyPhoto" not in titles
+    assert "PendingPhoto" not in titles
+    assert "RejectedPhoto" not in titles
     assert "ApprovedPhoto" in titles
+
+
+@pytest.mark.django_db
+def test_public_search_main_photo_exposes_only_approved_room_images():
+    cache.clear()
+
+    owner = User.objects.create_user(
+        username="main_photo_owner",
+        password="pass123",
+        email="main-photo-owner@example.com",
+    )
+    category = RoomCategorie.objects.create(
+        name="Main Photo Moderation",
+        active=True,
+    )
+
+    legacy_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="Legacy Main Photo",
+        legacy_image="rooms/legacy-main.jpg",
+    )
+
+    pending_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="Pending Main Photo",
+    )
+    RoomImage.objects.create(
+        room=pending_room,
+        image="rooms/pending-main.jpg",
+        status="pending",
+    )
+
+    rejected_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="Rejected Main Photo",
+    )
+    RoomImage.objects.create(
+        room=rejected_room,
+        image="rooms/rejected-main.jpg",
+        status="rejected",
+    )
+
+    approved_room = create_active_room(
+        owner=owner,
+        category=category,
+        title="Approved Main Photo",
+    )
+    RoomImage.objects.create(
+        room=approved_room,
+        image="rooms/approved-main.jpg",
+        status="approved",
+    )
+
+    response = APIClient().get(
+        reverse("v1:search-rooms"),
+        {"q": "Main Photo"},
+    )
+
+    assert response.status_code == 200, response.data
+
+    results = extract_results(response)
+    rooms_by_id = {item["id"]: item for item in results}
+
+    assert rooms_by_id[legacy_room.id]["main_photo"] is None
+    assert rooms_by_id[legacy_room.id]["photo_count"] == 0
+
+    assert rooms_by_id[pending_room.id]["main_photo"] is None
+    assert rooms_by_id[pending_room.id]["photo_count"] == 0
+
+    assert rooms_by_id[rejected_room.id]["main_photo"] is None
+    assert rooms_by_id[rejected_room.id]["photo_count"] == 0
+
+    approved_main_photo = rooms_by_id[approved_room.id]["main_photo"]
+
+    assert approved_main_photo is not None
+    assert approved_main_photo.endswith("/media/rooms/approved-main.jpg")
+    assert rooms_by_id[approved_room.id]["photo_count"] == 1

--- a/property/propertylist_app/tests/security/test_room_creation_throttle.py
+++ b/property/propertylist_app/tests/security/test_room_creation_throttle.py
@@ -1,0 +1,89 @@
+from datetime import date, timedelta
+
+import pytest
+from django.core.cache import caches
+from django.urls import reverse
+from rest_framework.settings import api_settings
+from rest_framework.test import APIClient
+
+from propertylist_app.models import Room
+
+
+@pytest.mark.django_db
+def test_authenticated_user_room_creation_is_throttled(
+    django_user_model,
+    settings,
+    monkeypatch,
+):
+    """
+    The same authenticated user may create two rooms when the test rate is
+    2/hour. The third rapid creation attempt must return HTTP 429.
+    """
+
+    monkeypatch.setitem(
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"],
+        "room-create",
+        "2/hour",
+    )
+
+    api_settings.reload()
+    caches["default"].clear()
+
+    user = django_user_model.objects.create_user(
+        username="room_spammer",
+        email="room_spammer@example.com",
+        password="TestPass123!",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    url = reverse("api:room-list")
+    future_available_from = (date.today() + timedelta(days=30)).isoformat()
+
+    def make_payload(index):
+        return {
+            "title": f"Throttle test room {index}",
+            "description": (
+                "This is a bright and spacious room with plenty of natural "
+                "light, modern furnishings, fast broadband, secure entry, "
+                "and excellent transport links to shops and the city centre."
+            ),
+            "location": "SW1A 1AA",
+            "price_per_month": "800.00",
+            "security_deposit": "800.00",
+            "available_from": future_available_from,
+            "availability_from_time": "10:00",
+            "availability_to_time": "18:00",
+            "view_available_days_mode": "everyday",
+            "min_stay_months": 1,
+            "max_stay_months": 6,
+            "furnished": False,
+            "bills_included": False,
+            "property_type": "flat",
+            "parking_available": False,
+            "action": "next",
+        }
+
+    first_response = client.post(
+        url,
+        make_payload(1),
+        format="json",
+    )
+    assert first_response.status_code == 201, first_response.data
+
+    second_response = client.post(
+        url,
+        make_payload(2),
+        format="json",
+    )
+    assert second_response.status_code == 201, second_response.data
+
+    third_response = client.post(
+        url,
+        make_payload(3),
+        format="json",
+    )
+
+    assert third_response.status_code == 429, third_response.data
+    assert Room.objects.filter(property_owner=user).count() == 2

--- a/property/propertylist_app/validators/__init__.py
+++ b/property/propertylist_app/validators/__init__.py
@@ -5,7 +5,7 @@ Usage everywhere:
     from propertylist_app.validators import validate_price, normalize_uk_postcode, ...
 """
 
-# ✅ FIX: import image validators RELATIVELY from this package (no self-import)
+#  FIX: import image validators RELATIVELY from this package (no self-import)
 from .images import (
     validate_avatar_image,
     validate_listing_photos,
@@ -57,6 +57,7 @@ from .security import (
     assert_not_duplicate_listing,
     
     sanitize_plain_text,
+    validate_plain_text,
     normalise_email,
 )
 
@@ -90,4 +91,5 @@ __all__ = [
     # normalisation / quotas
     "normalise_price", "normalize_price", "normalise_phone", "normalise_name", "enforce_user_caps",
     "assert_not_duplicate_listing",
+    "validate_plain_text",
 ]

--- a/property/propertylist_app/validators/security.py
+++ b/property/propertylist_app/validators/security.py
@@ -117,6 +117,36 @@ def sanitize_plain_text(value: str, *, max_len: int | None = None) -> str:
     return value
 
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+_DANGEROUS_SCHEME_RE = re.compile(
+    r"^\s*(?:javascript|vbscript|data\s*:\s*text/html)\s*:",
+    re.IGNORECASE,
+)
+
+
+def validate_plain_text(value: str, *, max_len: int | None = None) -> str:
+    """
+    Validate plain-text fields.
+
+    Intended for fields that should never contain HTML, such as:
+      - listing titles
+      - occupations
+      - contact subjects/messages
+
+    Performs existing plain-text normalisation, then rejects HTML-like input.
+    """
+    value = sanitize_plain_text(value, max_len=max_len)
+
+    if _HTML_TAG_RE.search(value):
+        raise ValidationError("HTML is not allowed in this field.")
+
+    if _DANGEROUS_SCHEME_RE.search(value):
+        raise ValidationError("Unsafe content is not allowed in this field.")
+
+    return value
+
+
 def normalise_email(value: str) -> str:
     return (value or "").strip().lower()
 
@@ -170,13 +200,15 @@ def normalise_phone(value: str) -> str:
 
 def validate_listing_title(value: str) -> str:
     """Reasonable constraints on listing titles."""
-    value = (value or "").strip()
+    value = validate_plain_text(value)
+
     if not value:
         raise ValidationError("Title is required.")
     if len(value) < 5:
         raise ValidationError("Title is too short (min 5 characters).")
     if len(value) > 120:
         raise ValidationError("Title is too long (max 120 characters).")
+
     return value
 
 


### PR DESCRIPTION
## What changed

### Security & Validation
- Strengthened input validation using `validate_plain_text` where appropriate.
- Improved validation for profile and contact form fields.
- Added and updated validation-related tests.

### Public photo moderation
- Public search now exposes only approved `RoomImage` records.
- Removed legacy `Room.image` fallback from public search results.
- `main_photo` now returns `null` unless an approved image exists.
- `photo_count` now counts approved moderated images only.
- `photos_only=true` now returns only listings with approved photos.
- Owner-only photo visibility remains unchanged.

### Throttling
- Added and refined throttling rules.
- Added security tests covering room creation throttling.

## Why

These changes improve platform security and ensure that unapproved or rejected listing photos cannot appear in public search results while strengthening request validation and abuse protection.

## Area

- [x] Backend
- [ ] Web
- [ ] Mobile
- [ ] Docs
- [x] Fix
- [x] Security

## Testing

Verified with targeted test suites:

-  Search tests (17 passed)
-  Photo moderation tests (6 passed)
-  Room photo visibility tests (3 passed)
-  Public search photo moderation regression tests (2 passed)

Also verified:

- `python -m py_compile` completed successfully for updated modules.

## Screenshots

N/A

## Linked issue

N/A