### PR TITLE
Add authenticated tenancy detail endpoint

### DIFF
--- a/property/openapi_v1.yaml
+++ b/property/openapi_v1.yaml
@@ -1293,25 +1293,15 @@ paths:
       - bookings
       requestBody:
         content:
-          type:
+          application/json:
             schema:
-              type: object
-              additionalProperties: {}
-              description: Unspecified request body
-          properties:
+              $ref: '#/components/schemas/CreateViewingBooking'
+          application/x-www-form-urlencoded:
             schema:
-              slot_id:
-                type: integer
-              room_id:
-                type: integer
-              start:
-                type: string
-                format: date-time
-          required:
+              $ref: '#/components/schemas/CreateViewingBooking'
+          multipart/form-data:
             schema:
-              type: object
-              additionalProperties: {}
-              description: Unspecified request body
+              $ref: '#/components/schemas/CreateViewingBooking'
       security:
       - jwtAuth: []
       responses:
@@ -4285,6 +4275,35 @@ paths:
                 required:
                 - ok
                 - data
+          description: ''
+  /api/v1/tenancies/{tenancy_id}/:
+    get:
+      operationId: tenancies_retrieve
+      description: Return one tenancy belonging to the authenticated landlord or tenant.
+      parameters:
+      - in: path
+        name: tenancy_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - tenancies
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenancyDetailOkResponse'
+          description: ''
+        '401':
+          description: Authentication required.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
           description: ''
   /api/v1/tenancies/{tenancy_id}/extensions/:
     post:
@@ -7307,6 +7326,16 @@ components:
       required:
       - data
       - ok
+    CreateViewingBooking:
+      type: object
+      properties:
+        slot_id:
+          type: integer
+        room_id:
+          type: integer
+        start:
+          type: string
+          format: date-time
     DashboardOverviewData:
       type: object
       properties:
@@ -8457,6 +8486,43 @@ components:
       properties:
         marketing_consent:
           type: boolean
+        theme:
+          enum:
+          - system
+          - light
+          - dark
+          type: string
+          description: |-
+            * `system` - System default
+            * `light` - Light
+            * `dark` - Dark
+          x-spec-enum-id: 26d45b5d8de5ebe4
+        date_format:
+          enum:
+          - DD/MM/YYYY
+          - MM/DD/YYYY
+          - YYYY-MM-DD
+          type: string
+          description: |-
+            * `DD/MM/YYYY` - DD/MM/YYYY
+            * `MM/DD/YYYY` - MM/DD/YYYY
+            * `YYYY-MM-DD` - YYYY-MM-DD
+          x-spec-enum-id: 7ebeab0d414e4561
+        time_format:
+          enum:
+          - 12h
+          - 24h
+          type: string
+          description: |-
+            * `12h` - 12-hour
+            * `24h` - 24-hour
+          x-spec-enum-id: 894a8d05df2732b5
+        notify_email:
+          type: boolean
+        notify_push:
+          type: boolean
+        notify_sms:
+          type: boolean
         notify_rentout_updates:
           type: boolean
         notify_reminders:
@@ -8464,6 +8530,16 @@ components:
         notify_messages:
           type: boolean
         notify_confirmations:
+          type: boolean
+        notify_weekly_reports:
+          type: boolean
+        notify_monthly_reports:
+          type: boolean
+        notify_system_alerts:
+          type: boolean
+        notify_user_reports:
+          type: boolean
+        notify_payment_alerts:
           type: boolean
     NotificationPreferencesOkResponse:
       type: object
@@ -8866,6 +8942,43 @@ components:
       properties:
         marketing_consent:
           type: boolean
+        theme:
+          enum:
+          - system
+          - light
+          - dark
+          type: string
+          description: |-
+            * `system` - System default
+            * `light` - Light
+            * `dark` - Dark
+          x-spec-enum-id: 26d45b5d8de5ebe4
+        date_format:
+          enum:
+          - DD/MM/YYYY
+          - MM/DD/YYYY
+          - YYYY-MM-DD
+          type: string
+          description: |-
+            * `DD/MM/YYYY` - DD/MM/YYYY
+            * `MM/DD/YYYY` - MM/DD/YYYY
+            * `YYYY-MM-DD` - YYYY-MM-DD
+          x-spec-enum-id: 7ebeab0d414e4561
+        time_format:
+          enum:
+          - 12h
+          - 24h
+          type: string
+          description: |-
+            * `12h` - 12-hour
+            * `24h` - 24-hour
+          x-spec-enum-id: 894a8d05df2732b5
+        notify_email:
+          type: boolean
+        notify_push:
+          type: boolean
+        notify_sms:
+          type: boolean
         notify_rentout_updates:
           type: boolean
         notify_reminders:
@@ -8873,6 +8986,16 @@ components:
         notify_messages:
           type: boolean
         notify_confirmations:
+          type: boolean
+        notify_weekly_reports:
+          type: boolean
+        notify_monthly_reports:
+          type: boolean
+        notify_system_alerts:
+          type: boolean
+        notify_user_reports:
+          type: boolean
+        notify_payment_alerts:
           type: boolean
     PatchedPrivacyPreferences:
       type: object
@@ -8991,10 +9114,6 @@ components:
             type: string
             format: uri
           nullable: true
-          readOnly: true
-        preview_image:
-          type: string
-          format: uri
           readOnly: true
         image_status:
           type: string
@@ -9644,6 +9763,9 @@ components:
           readOnly: true
         marketing_consent:
           type: boolean
+        preferred_timezone:
+          type: string
+          maxLength: 64
         notify_rentout_updates:
           type: boolean
         notify_reminders:
@@ -10160,10 +10282,6 @@ components:
             type: string
             format: uri
           nullable: true
-          readOnly: true
-        preview_image:
-          type: string
-          format: uri
           readOnly: true
         image_status:
           type: string
@@ -10707,7 +10825,6 @@ components:
       - owner_name
       - owner_username
       - paid_until
-      - preview_image
       - price_per_month
       - property_owner
       - property_type
@@ -10891,10 +11008,6 @@ components:
             * `rejected` - Rejected
           x-spec-enum-id: de3702061fc1d433
           readOnly: true
-        preview_image:
-          type: string
-          format: uri
-          nullable: true
       required:
       - id
       - image
@@ -11338,6 +11451,20 @@ components:
             * `cancelled` - Cancelled
           x-spec-enum-id: bed60eff9785955c
           readOnly: true
+        can_agree:
+          type: boolean
+          readOnly: true
+        can_edit:
+          type: boolean
+          readOnly: true
+        available_actions:
+          type: array
+          items:
+            type: string
+          readOnly: true
+        tenancy_action_reason:
+          type: string
+          readOnly: true
         review_open_at:
           type: string
           format: date-time
@@ -11373,6 +11500,9 @@ components:
           format: date-time
           readOnly: true
       required:
+      - available_actions
+      - can_agree
+      - can_edit
       - can_leave_review
       - created_at
       - duration_months
@@ -11390,10 +11520,24 @@ components:
       - status
       - still_living_check_at
       - still_living_confirmed_at
+      - tenancy_action_reason
       - tenant
       - tenant_confirmed_at
       - tenant_name
       - updated_at
+    TenancyDetailOkResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        message:
+          type: string
+          nullable: true
+        data:
+          $ref: '#/components/schemas/TenancyDetail'
+      required:
+      - data
+      - ok
     TenancyExtensionCreate:
       type: object
       properties:
@@ -11859,6 +12003,9 @@ components:
           readOnly: true
         marketing_consent:
           type: boolean
+        preferred_timezone:
+          type: string
+          maxLength: 64
         notify_rentout_updates:
           type: boolean
         notify_reminders:

--- a/property/propertylist_app/api/urls.py
+++ b/property/propertylist_app/api/urls.py
@@ -25,7 +25,7 @@ from propertylist_app.api.views import (
     UserReviewsView,UserReviewSummaryView, ReviewCreateView, ReviewListView, ReviewDetailView,
 
     # Tenancy (rental confirmation)
-    TenancyRespondView,TenancyProposeView, MyTenanciesView,TenancyStillLivingConfirmView,TenancyExtensionCreateView,TenancyExtensionRespondView,
+    TenancyRespondView, TenancyProposeView, TenancyDetailView, MyTenanciesView, TenancyStillLivingConfirmView, TenancyExtensionCreateView, TenancyExtensionRespondView,
 
    # Tenancy-based reviews
     TenancyReviewCreateView,
@@ -133,8 +133,9 @@ urlpatterns = [
 
     # Tenancy (rental confirmation)
     path("tenancies/propose/", TenancyProposeView.as_view(), name="tenancy-propose"),
-    path("tenancies/<int:tenancy_id>/respond/", TenancyRespondView.as_view(), name="tenancy-respond"),
     path("tenancies/mine/", MyTenanciesView.as_view(), name="my-tenancies"),
+    path("tenancies/<int:tenancy_id>/", TenancyDetailView.as_view(), name="tenancy-detail"),
+    path("tenancies/<int:tenancy_id>/respond/", TenancyRespondView.as_view(), name="tenancy-respond"),
 
     path("tenancies/<int:tenancy_id>/still-living/confirm/",TenancyStillLivingConfirmView.as_view(),name="tenancy-still-living-confirm",),
     path("tenancies/<int:tenancy_id>/extensions/",TenancyExtensionCreateView.as_view(),name="tenancy-extension-create",),

--- a/property/propertylist_app/api/views/__init__.py
+++ b/property/propertylist_app/api/views/__init__.py
@@ -54,6 +54,7 @@ from .reviews import (
 from .tenancies import (
     TenancyRespondView,
     TenancyProposeView,
+    TenancyDetailView,
     MyTenanciesView,
     TenancyStillLivingConfirmView,
     TenancyExtensionCreateView,

--- a/property/propertylist_app/api/views/bookings.py
+++ b/property/propertylist_app/api/views/bookings.py
@@ -32,6 +32,7 @@ from propertylist_app.api.serializers import (
     BookingPreflightRequestSerializer,
     BookingPreflightResponseSerializer,
     BookingRescheduleSerializer,
+    CreateViewingBookingSerializer,
 )
 from ..serializers import BookingCreateRequestSerializer, BookingResponseEnvelopeSerializer
 from .common import ok_response, _pagination_meta, _wrap_response_success, error_response
@@ -123,15 +124,7 @@ def create_booking(request):
 
 # propertylist_app/api/views/bookings.py
 @extend_schema(
-    request={
-        "type": "object",
-        "properties": {
-            "slot_id": {"type": "integer"},
-            "room_id": {"type": "integer"},
-            "start": {"type": "string", "format": "date-time"},
-        },
-        "required": [],
-    },
+    request=CreateViewingBookingSerializer,
     responses={
         200: {
             "type": "object",

--- a/property/propertylist_app/api/views/tenancies.py
+++ b/property/propertylist_app/api/views/tenancies.py
@@ -396,6 +396,61 @@ class TenancyRespondView(APIView):
             status_code=status.HTTP_200_OK,
         )               
         
+
+
+class TenancyDetailView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        responses={
+            200: inline_serializer(
+                name="TenancyDetailOkResponse",
+                fields={
+                    "ok": serializers.BooleanField(),
+                    "message": serializers.CharField(
+                        required=False,
+                        allow_null=True,
+                    ),
+                    "data": TenancyDetailSerializer(),
+                },
+            ),
+            401: OpenApiResponse(description="Authentication required."),
+            404: DetailResponseSerializer,
+        },
+        description=(
+            "Return one tenancy belonging to the authenticated landlord "
+            "or tenant."
+        ),
+    )
+    def get(self, request, tenancy_id):
+        Tenancy = apps.get_model("propertylist_app", "Tenancy")
+
+        tenancy = (
+            Tenancy.objects.select_related(
+                "room",
+                "landlord",
+                "tenant",
+                "tenant__profile",
+            )
+            .filter(
+                Q(landlord=request.user) | Q(tenant=request.user),
+                id=tenancy_id,
+            )
+            .first()
+        )
+
+        if not tenancy:
+            raise NotFound("Tenancy not found.")
+
+        return ok_response(
+            TenancyDetailSerializer(
+                tenancy,
+                context={"request": request},
+            ).data,
+            message="Tenancy retrieved successfully.",
+            status_code=status.HTTP_200_OK,
+        )        
+        
         
         
 

--- a/property/propertylist_app/tests/tenancies/test_tenancy_detail_endpoint.py
+++ b/property/propertylist_app/tests/tenancies/test_tenancy_detail_endpoint.py
@@ -1,0 +1,151 @@
+from datetime import date, timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from propertylist_app.models import Room, RoomCategorie, Tenancy
+
+
+pytestmark = pytest.mark.django_db
+
+API_PREFIX = "/api/v1"
+
+
+def _make_user(username: str):
+    User = get_user_model()
+
+    return User.objects.create_user(
+        username=username,
+        password="pass12345",
+        email=f"{username}@example.com",
+    )
+
+
+def _make_room(owner):
+    category = RoomCategorie.objects.create(name="Standard")
+
+    return Room.objects.create(
+        title="Tenancy detail test room",
+        description="Clean room",
+        price_per_month="500.00",
+        location="Southampton",
+        category=category,
+        furnished=False,
+        bills_included=False,
+        property_owner=owner,
+        property_type="flat",
+    )
+
+
+def _make_tenancy(*, landlord, tenant, room):
+    return Tenancy.objects.create(
+        room=room,
+        landlord=landlord,
+        tenant=tenant,
+        proposed_by=landlord,
+        move_in_date=date.today() + timedelta(days=7),
+        duration_months=6,
+        status=Tenancy.STATUS_PROPOSED,
+    )
+
+
+def _authenticated_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def test_landlord_can_retrieve_own_tenancy():
+    landlord = _make_user("detail_landlord")
+    tenant = _make_user("detail_tenant")
+    room = _make_room(landlord)
+    tenancy = _make_tenancy(
+        landlord=landlord,
+        tenant=tenant,
+        room=room,
+    )
+
+    client = _authenticated_client(landlord)
+
+    response = client.get(
+        f"{API_PREFIX}/tenancies/{tenancy.id}/",
+    )
+
+    assert response.status_code == 200, response.data
+    assert response.data["ok"] is True
+    assert response.data["data"]["id"] == tenancy.id
+    assert response.data["data"]["landlord"] == landlord.id
+    assert response.data["data"]["tenant"] == tenant.id
+
+    # The original proposer must wait for the other party.
+    assert response.data["data"]["can_agree"] is False
+    assert response.data["data"]["can_edit"] is False
+    assert response.data["data"]["available_actions"] == []
+
+
+def test_tenant_can_retrieve_own_tenancy_with_review_actions():
+    landlord = _make_user("detail_landlord_two")
+    tenant = _make_user("detail_tenant_two")
+    room = _make_room(landlord)
+    tenancy = _make_tenancy(
+        landlord=landlord,
+        tenant=tenant,
+        room=room,
+    )
+
+    client = _authenticated_client(tenant)
+
+    response = client.get(
+        f"{API_PREFIX}/tenancies/{tenancy.id}/",
+    )
+
+    assert response.status_code == 200, response.data
+    assert response.data["data"]["id"] == tenancy.id
+    assert response.data["data"]["can_agree"] is True
+    assert response.data["data"]["can_edit"] is True
+    assert response.data["data"]["available_actions"] == [
+        "confirm",
+        "propose_changes",
+    ]
+
+
+def test_unrelated_user_receives_not_found():
+    landlord = _make_user("detail_landlord_three")
+    tenant = _make_user("detail_tenant_three")
+    unrelated_user = _make_user("detail_outsider")
+    room = _make_room(landlord)
+    tenancy = _make_tenancy(
+        landlord=landlord,
+        tenant=tenant,
+        room=room,
+    )
+
+    client = _authenticated_client(unrelated_user)
+
+    response = client.get(
+        f"{API_PREFIX}/tenancies/{tenancy.id}/",
+    )
+
+    assert response.status_code == 404, response.data
+
+
+def test_missing_tenancy_returns_not_found():
+    user = _make_user("detail_missing_user")
+    client = _authenticated_client(user)
+
+    response = client.get(
+        f"{API_PREFIX}/tenancies/999999/",
+    )
+
+    assert response.status_code == 404, response.data
+
+
+def test_authentication_is_required():
+    client = APIClient()
+
+    response = client.get(
+        f"{API_PREFIX}/tenancies/999999/",
+    )
+
+    assert response.status_code == 401, response.data


### PR DESCRIPTION
## Summary

Adds a new authenticated tenancy detail endpoint:

GET /api/v1/tenancies/{tenancy_id}/

## Behaviour

- Allows the tenancy landlord to retrieve the tenancy
- Allows the tenancy tenant to retrieve the tenancy
- Returns 404 for unrelated users
- Returns 404 when the tenancy does not exist
- Returns 401 for unauthenticated requests

## Additional changes

- Added the endpoint to the OpenAPI schema
- Fixed the existing CreateViewingBooking request schema annotation
- Added dedicated tenancy detail endpoint tests

## Testing

- 5 tenancy detail endpoint tests passed
- 52 tenancy tests passed
- OpenAPI validation completed with 0 errors
- Full suite: 625 passed, 1 skipped
- 3 unrelated existing photo moderation test failures remain