### PR TITLE
Use Sidecar assets for Swagger UI

### DIFF
--- a/property/property/settings.py
+++ b/property/property/settings.py
@@ -390,6 +390,11 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "v1",
     "DESCRIPTION": "Backend API for RentOut property platform.",
     "SERVE_INCLUDE_SCHEMA": False,
+    
+    "SWAGGER_UI_DIST": "SIDECAR",
+    "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+    "REDOC_DIST": "SIDECAR",
+    
     "SCHEMA_PATH_PREFIX": r"/api/v1",
     "SERVERS": [
         *(


### PR DESCRIPTION
## What changed
- Configure Swagger UI to use drf-spectacular-sidecar assets.
- Configure Redoc to use sidecar assets.

## Why
- Fix blank Swagger UI caused by the Content Security Policy blocking external CDN assets.

## Testing
- python manage.py check
- Verified SWAGGER_UI_DIST = SIDECAR
- Verified REDOC_DIST = SIDECAR